### PR TITLE
feat: add /badge/request endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check": "prettier . --check"
   },
   "dependencies": {
+    "@noble/hashes": "^1.5.0",
     "@nostr-dev-kit/ndk": "^2.10.1",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@noble/hashes':
+    specifier: ^1.5.0
+    version: 1.5.0
   '@nostr-dev-kit/ndk':
     specifier: ^2.10.1
     version: 2.10.1(typescript@5.6.2)
@@ -455,14 +458,14 @@ packages:
     resolution: {integrity: sha512-osvveYtyzdEVbt3OfwwXFr4P2iVBL5u1Q3q4ONBfDY/UpOuXmOlbgwc1xECEboY8wIays8Yt6onaWMUdUbfl0A==}
     dependencies:
       '@noble/curves': 1.1.0
-      '@noble/hashes': 1.3.1
+      '@noble/hashes': 1.3.2
       '@scure/base': 1.1.1
     dev: false
 
   /@scure/bip39@1.2.1:
     resolution: {integrity: sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==}
     dependencies:
-      '@noble/hashes': 1.3.1
+      '@noble/hashes': 1.3.2
       '@scure/base': 1.1.1
     dev: false
 

--- a/src/app/api/badge/request/route.ts
+++ b/src/app/api/badge/request/route.ts
@@ -1,0 +1,89 @@
+import { buildAwardEvent, requiredEnvVar } from '@/lib/utils';
+import { hexToBytes } from '@noble/hashes/utils';
+import NDK, {
+  NDKEvent,
+  NDKKind,
+  NDKPrivateKeySigner,
+} from '@nostr-dev-kit/ndk';
+import { NextResponse } from 'next/server';
+import { getPublicKey } from 'nostr-tools';
+import { queryProfile } from 'nostr-tools/nip05';
+
+const relaysList = ['wss://relay.damus.io', 'wss://relay.hodl.ar'];
+const NOSTR_SIGNER = requiredEnvVar('NOSTR_SIGNER');
+
+const handleErrorResponse = (message: string, status: number) => {
+  return NextResponse.json({ error: message }, { status });
+};
+
+export async function POST(request: Request) {
+  if (!NOSTR_SIGNER) return handleErrorResponse('Missing admin signer', 422);
+
+  const params = await request.json();
+  const { badgeId, nip05 } = params;
+
+  if (!badgeId)
+    return handleErrorResponse(
+      'Missing badge definition event id (badgeId)',
+      401
+    );
+
+  if (!nip05) return handleErrorResponse('Missing nip05 on request', 401);
+
+  const nip05Profile = await queryProfile(nip05);
+  if (!nip05Profile) return handleErrorResponse('Invalid nip05', 401);
+
+  const signer = new NDKPrivateKeySigner(NOSTR_SIGNER);
+  const signerPubkey = getPublicKey(hexToBytes(NOSTR_SIGNER));
+
+  const ndk = new NDK({ explicitRelayUrls: relaysList, signer });
+  await ndk.connect();
+
+  const badgeDefinitionEvent = await ndk.fetchEvent({
+    ids: [badgeId],
+  });
+
+  const badgeIdentifier =
+    badgeDefinitionEvent?.getMatchingTags('d')[0]?.[1] ?? null;
+
+  if (
+    !badgeDefinitionEvent ||
+    badgeDefinitionEvent.kind !== NDKKind.BadgeDefinition ||
+    badgeDefinitionEvent.pubkey !== signerPubkey ||
+    !badgeIdentifier
+  )
+    return handleErrorResponse(
+      'Missing or invalid badge definition event',
+      401
+    );
+
+  const badgeAddress = `${NDKKind.BadgeDefinition}:${signerPubkey}:${badgeIdentifier}`;
+  const alreadyExistAward = await ndk.fetchEvent({
+    kinds: [NDKKind.BadgeAward],
+    authors: [signerPubkey],
+    '#a': [badgeAddress],
+    '#p': [nip05Profile.pubkey],
+  });
+
+  if (alreadyExistAward)
+    return handleErrorResponse(
+      'The award event has already been sent for this nip05',
+      401
+    );
+
+  const awardEvent: NDKEvent = new NDKEvent(
+    ndk,
+    buildAwardEvent(badgeAddress, signerPubkey, nip05Profile.pubkey)
+  );
+
+  await awardEvent.sign();
+  await awardEvent.publish();
+
+  if (awardEvent.publishStatus === 'error')
+    return handleErrorResponse(
+      'An error occurred while trying to publish the award event',
+      401
+    );
+
+  return NextResponse.json({ message: awardEvent }, { status: 200 });
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,37 @@
+import { NDKKind } from '@nostr-dev-kit/ndk';
 import { clsx, type ClassValue } from 'clsx';
+import { UnsignedEvent } from 'nostr-tools';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+export const requiredEnvVar = (key: string): string => {
+  const envVar = process.env[key];
+  if (undefined === envVar) {
+    throw new Error(`Environment process ${key} must be defined`);
+  }
+  return envVar;
+};
+
+export const nowInSeconds = (): number => {
+  return Math.floor(Date.now() / 1000);
+};
+
+export function buildAwardEvent(
+  badgeAddress: string,
+  senderPubkey: string,
+  receiverPubkey: string
+): UnsignedEvent {
+  return {
+    kind: NDKKind.BadgeAward,
+    pubkey: senderPubkey,
+    created_at: nowInSeconds(),
+    content: '{}',
+    tags: [
+      ['a', badgeAddress],
+      ['p', receiverPubkey],
+    ],
+  };
 }


### PR DESCRIPTION
# Description
This pull request adds a new API endpoint that allows awarding a badge to a user through their NIP-05 identifier. The endpoint accepts two parameters:

1. badgeId: A 32-character hex string representing a badge definition event.
2. nip05: The NIP-05 identifier of the user receiving the badge.

# How it works
- The endpoint first retrieves the public key associated with the provided NIP-05.

- It then checks if the badge definition (badgeId) is valid and was created by the authorized signer (configured via an environment variable).

- The system also verifies that no badge has been awarded to this user for this badge definition before.

- If everything is valid, the badge award event is created, signed, and published to the Nostr relays.

- If any step fails, a meaningful error message is returned.